### PR TITLE
Fix key delete

### DIFF
--- a/runserver.py
+++ b/runserver.py
@@ -161,7 +161,7 @@ def keys(host, port, db):
     List keys for one database
     """
     s = time.time()
-    r = redis.StrictRedis(host=host, port=port, db=db)
+    r = redis.StrictRedis(host=host, port=port, db=db, charset="utf-8", decode_responses=True)
     if request.method == "POST":
         action = request.form["action"]
         app.logger.debug(action)

--- a/templates/keys.html
+++ b/templates/keys.html
@@ -42,7 +42,7 @@
 	    	<tr>
 	    		<td class="text-right" style="width: 5%">{{ loop.index + offset }}</td>
     		<td>{{ types[key] }}</td>
-	    		<td><a href="{{ key|urlsafe_base64 }}/">{{ key.decode('utf8') }}</a></td>
+	    		<td><a href="{{ key|urlsafe_base64 }}/">{{ key }}</a></td>
 					<td>{{ size[key] }}</td>
 	    		<td><form method="POST"><input type="hidden" name="action" value="delkey" /><input type="hidden" name="key" value="{{ key }}" /><button class="btn btn-default" type="submit" onclick="return confirm('Are you sure you want to delete this key? {{ key }}');"><span class="glyphicon glyphicon-trash"></span></button></form></td>
 	    	</tr>


### PR DESCRIPTION
In python3 redis was storing values as`'b"thekey"'` - a `str` type with `b'...'` as part of the string, instead of a `bytes` string representation.

This PR tells redis that the encoding is utf-8 so we don't have to manage it separately (at least in the keys endpoint)

Redis should support python 2 & 3 up to Redis v3.5.